### PR TITLE
Update links in lessons

### DIFF
--- a/src/lessons/filterByPaths.ts
+++ b/src/lessons/filterByPaths.ts
@@ -3,7 +3,7 @@ import { Lesson } from "./lesson";
 export const filterByPaths: Lesson = {
   title: `Filter by paths`,
 
-  description: `In addition to filtering by activities and branches you can also run workflows when specific files are changed - or not - with the [\`paths\` and \`paths-ignore\`](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestpaths) properties.
+  description: `In addition to filtering by activities and branches you can also run workflows when specific files are changed - or not - with the [\`paths\` and \`paths-ignore\`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore) properties.
 
 For this lesson, a workflow to optimize images should be run whenever a \`push\` to the repository includes \`.jpg\` files in the \`photos\` directory and not, when pictures are pushed in other locations.`,
 

--- a/src/lessons/filterPullRequestByBranch.ts
+++ b/src/lessons/filterPullRequestByBranch.ts
@@ -3,7 +3,7 @@ import { Lesson } from "./lesson";
 export const filterPullRequestByBranch: Lesson = {
   title: `Validate pull requests`,
 
-  description: `We have seen that workflows can run when a single event, or when one of multiple events happens. It is also possible to limit workflow execution to certain [branches or tags](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestbranchestags).
+  description: `We have seen that workflows can run when a single event, or when one of multiple events happens. It is also possible to limit workflow execution to certain [branches](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpull_requestpull_request_targetbranchesbranches-ignore) or [tags](hthttps://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore).
 
 This workflow should run only when a \`pull_request\` to the \`master\` branch is opened.
 `,

--- a/src/lessons/runForMultipleEvents.ts
+++ b/src/lessons/runForMultipleEvents.ts
@@ -3,7 +3,7 @@ import { Lesson } from "./lesson";
 export const runForMultipleEvents: Lesson = {
   title: `Run for multiple events`,
 
-  description: `Workflows can also run when any of [multiple events](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-using-a-list-of-events) occur.
+  description: `Workflows can also run when any of [multiple events](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#using-multiple-events) occur.
 
 Currently this workflow runs on every \`push\`, update it so that is also runs whenever any of the \`issues\` in the repository is modified.`,
 

--- a/src/lessons/runOnPush.ts
+++ b/src/lessons/runOnPush.ts
@@ -2,7 +2,7 @@ import { Lesson } from "./lesson";
 
 export const runOnPush: Lesson = {
   title: `Run on push`,
-  description: `Workflows [run](https://help.github.com/en/actions/reference/events-that-trigger-workflows#about-workflow-events) when a specific activity happens on GitHub, at a scheduled time, or when an event outside of GitHub occurs.
+  description: `Workflows [run](https://help.github.com/en/actions/reference/events-that-trigger-workflows) when a specific activity happens on GitHub, at a scheduled time, or when an event outside of GitHub occurs.
 
 Every workflow declares which event should trigger it by setting [\`on\`](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#on) to a string identifying an event.
 


### PR DESCRIPTION
This PR updates links to GitHub Actions docs that either jumps to the wrong page or uses a now-invalid page anchor.